### PR TITLE
feat(strapi): add Global single type with layout and link components

### DIFF
--- a/server/src/api/course/controllers/course.ts
+++ b/server/src/api/course/controllers/course.ts
@@ -2,6 +2,24 @@
  * course controller
  */
 
-import { factories } from '@strapi/strapi'
+// import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::course.course');
+// export default factories.createCoreController('api::course.course');
+
+
+
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::course.course', () => ({
+  async findOne(ctx) {
+    const { id } = ctx.params;
+    const entity = await strapi.db
+      .query('api::course.course')
+      .findOne({
+        where: { slug: id },
+        populate: ['*'],
+      });
+    return this.transformResponse(entity);
+  },
+}));

--- a/server/src/api/global/content-types/global/schema.json
+++ b/server/src/api/global/content-types/global/schema.json
@@ -1,0 +1,35 @@
+{
+  "kind": "singleType",
+  "collectionName": "globals",
+  "info": {
+    "singularName": "global",
+    "pluralName": "globals",
+    "displayName": "Global",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text",
+      "required": true
+    },
+    "header": {
+      "type": "component",
+      "repeatable": false,
+      "component": "layout.header",
+      "required": true
+    },
+    "footer": {
+      "type": "component",
+      "repeatable": false,
+      "component": "layout.footer",
+      "required": true
+    }
+  }
+}

--- a/server/src/api/global/controllers/global.ts
+++ b/server/src/api/global/controllers/global.ts
@@ -1,0 +1,7 @@
+/**
+ * global controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::global.global');

--- a/server/src/api/global/routes/global.ts
+++ b/server/src/api/global/routes/global.ts
@@ -1,0 +1,7 @@
+/**
+ * global router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::global.global');

--- a/server/src/api/global/services/global.ts
+++ b/server/src/api/global/services/global.ts
@@ -1,0 +1,7 @@
+/**
+ * global service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::global.global');

--- a/server/src/components/elements/group-link.json
+++ b/server/src/components/elements/group-link.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_elements_group_links",
+  "info": {
+    "displayName": "Group Link"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "links": {
+      "type": "component",
+      "repeatable": true,
+      "required": true,
+      "component": "elements.link"
+    }
+  }
+}

--- a/server/src/components/elements/link.json
+++ b/server/src/components/elements/link.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "components_elements_links",
+  "info": {
+    "displayName": "Link"
+  },
+  "options": {},
+  "attributes": {
+    "text": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    },
+    "isExternal": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/server/src/components/elements/social-link.json
+++ b/server/src/components/elements/social-link.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "components_elements_social_links",
+  "info": {
+    "displayName": "Social Link"
+  },
+  "options": {},
+  "attributes": {
+    "text": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    },
+    "iconName": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/server/src/components/layout/footer.json
+++ b/server/src/components/layout/footer.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_layout_footers",
+  "info": {
+    "displayName": "Footer",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "linkGroups": {
+      "type": "component",
+      "repeatable": true,
+      "required": true,
+      "component": "elements.group-link"
+    },
+    "socialLinks": {
+      "type": "component",
+      "repeatable": true,
+      "component": "elements.social-link",
+      "required": true
+    },
+    "legalLinks": {
+      "type": "component",
+      "repeatable": true,
+      "required": true,
+      "component": "elements.link"
+    }
+  }
+}

--- a/server/src/components/layout/header.json
+++ b/server/src/components/layout/header.json
@@ -1,0 +1,14 @@
+{
+  "collectionName": "components_layout_headers",
+  "info": {
+    "displayName": "Header"
+  },
+  "options": {},
+  "attributes": {
+    "navigation": {
+      "type": "component",
+      "repeatable": true,
+      "component": "elements.link"
+    }
+  }
+}

--- a/server/types/generated/components.d.ts
+++ b/server/types/generated/components.d.ts
@@ -1,3 +1,75 @@
-/*
- * The app doesn't have any components yet.
- */
+import type { Schema, Struct } from '@strapi/strapi';
+
+export interface ElementsGroupLink extends Struct.ComponentSchema {
+  collectionName: 'components_elements_group_links';
+  info: {
+    displayName: 'Group Link';
+  };
+  attributes: {
+    links: Schema.Attribute.Component<'elements.link', true> &
+      Schema.Attribute.Required;
+    title: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
+export interface ElementsLink extends Struct.ComponentSchema {
+  collectionName: 'components_elements_links';
+  info: {
+    displayName: 'Link';
+  };
+  attributes: {
+    isExternal: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    text: Schema.Attribute.String & Schema.Attribute.Required;
+    url: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
+export interface ElementsSocialLink extends Struct.ComponentSchema {
+  collectionName: 'components_elements_social_links';
+  info: {
+    displayName: 'Social Link';
+  };
+  attributes: {
+    iconName: Schema.Attribute.String & Schema.Attribute.Required;
+    text: Schema.Attribute.String & Schema.Attribute.Required;
+    url: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
+export interface LayoutFooter extends Struct.ComponentSchema {
+  collectionName: 'components_layout_footers';
+  info: {
+    description: '';
+    displayName: 'Footer';
+  };
+  attributes: {
+    legalLinks: Schema.Attribute.Component<'elements.link', true> &
+      Schema.Attribute.Required;
+    linkGroups: Schema.Attribute.Component<'elements.group-link', true> &
+      Schema.Attribute.Required;
+    socialLinks: Schema.Attribute.Component<'elements.social-link', true> &
+      Schema.Attribute.Required;
+  };
+}
+
+export interface LayoutHeader extends Struct.ComponentSchema {
+  collectionName: 'components_layout_headers';
+  info: {
+    displayName: 'Header';
+  };
+  attributes: {
+    navigation: Schema.Attribute.Component<'elements.link', true>;
+  };
+}
+
+declare module '@strapi/strapi' {
+  export module Public {
+    export interface ComponentSchemas {
+      'elements.group-link': ElementsGroupLink;
+      'elements.link': ElementsLink;
+      'elements.social-link': ElementsSocialLink;
+      'layout.footer': LayoutFooter;
+      'layout.header': LayoutHeader;
+    }
+  }
+}

--- a/server/types/generated/contentTypes.d.ts
+++ b/server/types/generated/contentTypes.d.ts
@@ -406,6 +406,40 @@ export interface ApiCourseCourse extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
+  collectionName: 'globals';
+  info: {
+    description: '';
+    displayName: 'Global';
+    pluralName: 'globals';
+    singularName: 'global';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.Text & Schema.Attribute.Required;
+    footer: Schema.Attribute.Component<'layout.footer', false> &
+      Schema.Attribute.Required;
+    header: Schema.Attribute.Component<'layout.header', false> &
+      Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::global.global'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    title: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiLessonLesson extends Struct.CollectionTypeSchema {
   collectionName: 'lessons';
   info: {
@@ -1002,6 +1036,7 @@ declare module '@strapi/strapi' {
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;
       'api::course.course': ApiCourseCourse;
+      'api::global.global': ApiGlobalGlobal;
       'api::lesson.lesson': ApiLessonLesson;
       'api::user-progress.user-progress': ApiUserProgressUserProgress;
       'plugin::content-releases.release': PluginContentReleasesRelease;


### PR DESCRIPTION
Added **single type**: `Global` — for storing shared layout configuration
- Created **components**:
  - `Layout/Header` — supports navigation links (logo will be added later)
  - `Layout/Footer` — includes footer text and social/media links
  - `Elements/Links*` - various link components